### PR TITLE
fixing versions + grisu3

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 target_link_libraries(benchmark PUBLIC fmt)
 target_link_libraries(benchmark PUBLIC cxxopts)
 
-target_link_libraries(benchmark PUBLIC grisu2)
+#target_link_libraries(benchmark PUBLIC grisu2)
 target_link_libraries(benchmark PUBLIC double-conversion)
 target_link_libraries(benchmark PUBLIC ryu::ryu)
 target_link_libraries(benchmark PUBLIC teju)

--- a/benchmarks/algorithms.h
+++ b/benchmarks/algorithms.h
@@ -26,6 +26,7 @@
 #include "dragon4.h"
 #include "dragonbox/dragonbox_to_chars.h"
 #include "grisu2.h"
+#include "grisu3.h"
 #include "grisu_exact.h"
 #include "ieeeToString.h"
 #include "ryu/ryu.h"
@@ -50,7 +51,8 @@ enum Algorithm {
   DOUBLE_CONVERSION = 12,
   ABSEIL = 13,
   STD_TO_CHARS = 14,
-  COUNT = 15
+  GRISU3 = 15,
+  COUNT = 16,
 };
 
 template<typename T>
@@ -158,11 +160,17 @@ int snprintf(T d, std::span<char>& buffer) {
   return std::snprintf(buffer.data(), buffer.size(), "%.17g", d);
 }
 
-// grisu2::dtoa_impl::grisu2 can take a template type
-// However, grisu2::to_chars is hardcoded for double.
+// grisu2 is hardcoded for double.
 template<arithmetic_float T>
 int grisu2(T d, std::span<char>& buffer) {
-  const char* newp = grisu2::to_chars(buffer.data(), nullptr, d);
+  const char* newp = grisu2::Dtoa(buffer.data(), d);
+  return newp - buffer.data();
+}
+
+// grisu3 is hardcoded for double.
+template<arithmetic_float T>
+int grisu3(T d, std::span<char>& buffer) {
+  const char* newp = grisu3::Dtoa(buffer.data(), d);
   return newp - buffer.data();
 }
 

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -149,7 +149,12 @@ int main(int argc, char **argv) {
         ("t,test", "Test the algorithms and find their properties.",
         cxxopts::value<bool>()->default_value("false"))
         ("d,dragon", "Enable dragon4 (current impl. triggers some asserts).",
+#ifdef NDEBUG
+        cxxopts::value<bool>()->default_value("true"))
+#else // NDEBUG
+        // dragon4 is not safe in debug mode: some asserts fire.
         cxxopts::value<bool>()->default_value("false"))
+#endif
         ("e,errol", "Enable errol3 (current impl. returns invalid values, e.g., for 0).",
         cxxopts::value<bool>()->default_value("false"))
         ("h,help", "Print usage.");
@@ -202,6 +207,7 @@ int main(int argc, char **argv) {
       args[Benchmarks::DOUBLE_CONVERSION] = { "double_conversion" , Benchmarks::double_conversion<T> , true };
       args[Benchmarks::ABSEIL]            = { "abseil"            , Benchmarks::abseil<T>            , ABSEIL_SUPPORTED };
       args[Benchmarks::STD_TO_CHARS]      = { "std::to_chars"     , Benchmarks::std_to_chars<T>      , TO_CHARS_SUPPORTED };
+      args[Benchmarks::GRISU3]            = { "grisu3"            , Benchmarks::grisu3<T>            , true };
       return args;
     };
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(NOT WIN32)
     add_subdirectory(netlib)
 endif()
-add_subdirectory(grisu2)
+#add_subdirectory(grisu2)
 
 include(FetchContent)
 include(ExternalProject)
@@ -14,7 +14,7 @@ if (NOT CYGWIN)
 
     FetchContent_Declare(abseil
          GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-         GIT_TAG "d7aaad8")
+         GIT_TAG "d9e4955") # Abseil LTS branch, January 2025, Patch 1
     FetchContent_GetProperties(abseil)
     if(NOT abseil_POPULATED)
         set(BUILD_TESTING OFF)
@@ -30,7 +30,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 FetchContent_Declare(
         doubleconversion
         GIT_REPOSITORY https://github.com/google/double-conversion.git
-        GIT_TAG "v3.1.5"
+        GIT_TAG "v3.3.1"
         GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(doubleconversion)
@@ -38,7 +38,7 @@ FetchContent_MakeAvailable(doubleconversion)
 FetchContent_Declare(
         teju_jagua
         GIT_REPOSITORY https://github.com/jaja360/teju_jagua.git
-        GIT_TAG main
+        GIT_TAG e62fcfc418170cdcba0fc842dcb5e93ead428ba6
         GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(teju_jagua)
@@ -55,7 +55,7 @@ endif()
 FetchContent_Declare(
         ryu
         GIT_REPOSITORY https://github.com/ulfjack/ryu
-        GIT_TAG master
+        GIT_TAG 1264a946ba66eab320e927bfd2362e0c8580c42f
         GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(ryu)
@@ -63,7 +63,7 @@ FetchContent_MakeAvailable(ryu)
 FetchContent_Declare(
         grisu-exact
         GIT_REPOSITORY https://github.com/jk-jeon/Grisu-Exact
-        GIT_TAG master
+        GIT_TAG 4279e63faa301c03112f56f9ee4ed8bdff947fee
         GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(grisu-exact)
@@ -80,7 +80,7 @@ FetchContent_MakeAvailable(dragonbox)
 FetchContent_Declare(
         drachennest # for schubfach and dragon4
         GIT_REPOSITORY https://github.com/abolz/Drachennest.git
-        GIT_TAG master
+        GIT_TAG e6714a39ad331b4489d0b6aaf3968635bff4eb5e
         GIT_SHALLOW TRUE
 )
 FetchContent_GetProperties(drachennest)
@@ -92,12 +92,15 @@ add_library(dragon_schubfach_lib STATIC
     ${drachennest_SOURCE_DIR}/src/dragon4.cc
     ${drachennest_SOURCE_DIR}/src/schubfach_32.cc
     ${drachennest_SOURCE_DIR}/src/schubfach_64.cc
+    ${drachennest_SOURCE_DIR}/src/grisu3.cc
+    ${drachennest_SOURCE_DIR}/src/grisu2.cc
+
 )
 target_include_directories(dragon_schubfach_lib PUBLIC
     ${drachennest_SOURCE_DIR}/src
 )
 
-CPMAddPackage("gh:fmtlib/fmt#11.0.2")
+CPMAddPackage("gh:fmtlib/fmt#11.1.4")
 CPMAddPackage(
   GITHUB_REPOSITORY jarro2783/cxxopts
   VERSION 3.2.0


### PR DESCRIPTION
This is some minor update. One notable change is that we reenable Dragon 4 as long as asserts are disabled.

See also https://www.overleaf.com/project/612d0072f8cbdccd65ae72d2 where version numbers are recorded.