### PR TITLE
specialize snprintf/abseil for float/double

### DIFF
--- a/benchmarks/algorithms.h
+++ b/benchmarks/algorithms.h
@@ -168,7 +168,10 @@ int netlib(T d, std::span<char>& buffer) {
 
 template<arithmetic_float T>
 int snprintf(T d, std::span<char>& buffer) {
-  return std::snprintf(buffer.data(), buffer.size(), "%.17g", d);
+  if constexpr (std::is_same_v<T, float>)
+    return std::snprintf(buffer.data(), buffer.size(), "%.9g", d);
+  else
+    return std::snprintf(buffer.data(), buffer.size(), "%.17g", d);
 }
 
 // grisu2 is hardcoded for double.
@@ -267,7 +270,10 @@ int abseil(T d, std::span<char>& buffer) {
   // absl::StrAppend(&s, d);
   // std::copy(s.begin(), s.end(), buffer.begin());
   // return size(s);
-  return absl::SNPrintF(buffer.data(), buffer.size(), "%g", d);
+  if constexpr (std::is_same_v<T, float>)
+    return absl::SNPrintF(buffer.data(), buffer.size(), "%.9g", d);
+  else
+    return absl::SNPrintF(buffer.data(), buffer.size(), "%.17g", d);
 }
 
 template<arithmetic_float T>
@@ -285,7 +291,6 @@ int std_to_chars(T d, std::span<char>& buffer) {
   std::abort();
 #endif
 }
-
 
 template <arithmetic_float T>
 std::array<BenchArgs<T>, Benchmarks::COUNT> initArgs(bool errol = false) {


### PR DESCRIPTION
Currently, **snprintf** always had a `%.17g` format specifier, which is too long for a 32-bit float (`%.9g` is enough to guarantee round-trip validity), whereas **abseil** always had a `%g` specifier, which --- if abseil uses the same specifiers as printf, as I expect ---, means a precision of up to 6 significant digits, i.e., not enough to guarantee round-trip for either floats or doubles.