### PR TITLE
comparison between our to_chars and dragonbox's to_chars

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -47,14 +47,13 @@ void process(const std::vector<TestCase<T>> &lines,
              const std::array<BenchArgs<T>, Benchmarks::COUNT> &args,
              const std::vector<std::string> &algo_filter) {
   // We have a special algorithm for the string generation:
-  if (const std::string just_string = "just_string";
-      !algo_filtered_out(just_string, algo_filter)) {
+  if (!algo_filtered_out("just_string", algo_filter)) {
     std::vector<diy_float_t> parsed;
     for(const auto d : lines) {
       const auto v = jkj::grisu_exact(d.value);
       parsed.emplace_back(v.significand, v.exponent, v.is_negative);
     }
-    pretty_print(parsed, just_string, [](const std::vector<diy_float_t>& parsed) -> int {
+    pretty_print(parsed, "just_string_ours", [](const std::vector<diy_float_t>& parsed) -> int {
       int volume = 0;
       char buf[100];
       std::span<char> bufspan(buf, sizeof(buf));
@@ -62,8 +61,23 @@ void process(const std::vector<TestCase<T>> &lines,
         volume += to_chars(v.significand, v.exponent, v.is_negative, bufspan.data());
       return volume;
     }, 100);
+    pretty_print(parsed, "just_string_dragonbox", [](const std::vector<diy_float_t>& parsed) -> int {
+      using traits = jkj::dragonbox::default_float_traits<T>;
+      using carrier_uint = typename traits::carrier_uint;
+      int volume = 0;
+      char buf[100];
+      std::span<char> bufspan(buf, sizeof(buf));
+      for (const auto v : parsed) {
+        char* ptr = bufspan.data();
+        if(v.is_negative) *ptr++ = '-';
+        const char* end = jkj::dragonbox::to_chars_detail::to_chars<T, traits>(
+            static_cast<carrier_uint>(v.significand), v.exponent, ptr);
+        volume += end - bufspan.data();
+      }
+      return volume;
+    }, 100);
   } else {
-    fmt::println("# skipping {}", just_string);
+    fmt::println("# skipping just_string");
   }
 
   for (const auto &algo : args) {


### PR DESCRIPTION
Following the discussion in #24, I added a comparison of our to_chars and dragonbox's to_chars implementation.

Here are some results on my computer (Ryzen 9 9900x) :

```
❯ ./build/benchmarks/benchmark -a "just_string" -f ./data/canada.txt
number type: binary64 (double)
# read 111126 lines
just_string_ours              :  2813.98 MB/s (+/- 0.7 %)     2.09 MB      6.68 ns/f   149.68 Mfloat/s
                                    9.90 i/B   186.20 i/f (+/- 0.0 %)      1.97 c/B    37.07 c/f (+/- 0.2 %)
                                    5.02 i/c      0.00 b/f                 0.00 bm/f      5.55 GHz
just_string_dragonbox         :  4338.15 MB/s (+/- 1.2 %)     2.09 MB      4.33 ns/f   230.75 Mfloat/s
                                    5.65 i/B   106.28 i/f (+/- 0.0 %)      1.28 c/B    24.01 c/f (+/- 0.2 %)
                                    4.43 i/c      0.00 b/f                 0.00 bm/f      5.54 GHz

```