### PR TITLE
add script to compare perf. of different x86 level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
-build
-build_debug
-build_script
+build*
 .gdb_history
 outputs
 tags
 compile_commands.json
 .cache
+perf.data*
 *.log
 **/__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,21 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
 endif()
 
 include(CheckCXXCompilerFlag)
-unset(SIMPLE_FAST_FLOAT_BENCHMARK_COMPILER_SUPPORTS_MARCH_NATIVE CACHE)
-CHECK_CXX_COMPILER_FLAG(-march=native SIMPLE_FAST_FLOAT_BENCHMARK_COMPILER_SUPPORTS_MARCH_NATIVE)
-if(SIMPLE_FAST_FLOAT_BENCHMARK_COMPILER_SUPPORTS_MARCH_NATIVE)
-    add_compile_options(-march=native)
+set(SIMPLE_FAST_FLOAT_BENCHMARK_MARCH "" CACHE STRING
+    "Set -march value for benchmarks (e.g. native, x86-64-v4, etc)")
+
+if(NOT SIMPLE_FAST_FLOAT_BENCHMARK_MARCH)
+  set(_SFF_MARCH_FLAG "-march=native")
 else()
-     message(STATUS "native target not supported")
+  set(_SFF_MARCH_FLAG "-march=${SIMPLE_FAST_FLOAT_BENCHMARK_MARCH}")
+endif()
+
+CHECK_CXX_COMPILER_FLAG(${_SFF_MARCH_FLAG} _SFF_MARCH_SUPPORTED)
+if(_SFF_MARCH_SUPPORTED)
+  add_compile_options(${_SFF_MARCH_FLAG})
+  message(STATUS "Compiling with ${_SFF_MARCH_FLAG}")
+else()
+  message(STATUS "${_SFF_MARCH_FLAG} not supported, proceeding without -march flag.")
 endif()
 
 if (NOT CMAKE_BUILD_TYPE AND NOT SANITIZE)

--- a/scripts/test_x86_levels.bash
+++ b/scripts/test_x86_levels.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CPU=$1
+OutputDir="outputs/${CPU}"
+Algorithms="schubfach,dragonbox"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <CPU>"
+  exit 1
+fi
+
+mkdir -p ${OutputDir}
+for v in x86-64 x86-64-v2 x86-64-v3 x86-64-v4 native; do
+  cmake -B build-${v} -DSIMPLE_FAST_FLOAT_BENCHMARK_MARCH=${v}
+  cmake --build build-${v}
+
+  echo "Running benchmarks for ${v} on ${CPU}..."
+  ./build-${v}/benchmarks/benchmark -f data/canada.txt -a ${Algorithms} > ${OutputDir}/${CPU}_g++_canada_none_${v}.raw
+  ./build-${v}/benchmarks/benchmark -f data/mesh.txt -a ${Algorithms} > ${OutputDir}/${CPU}_g++_mesh_none_${v}.raw
+  ./build-${v}/benchmarks/benchmark -a ${Algorithms} > ${OutputDir}/${CPU}_g++_uniform_01_none_${v}.raw
+done
+
+for f in ${OutputDir}/*.raw; do
+  python3 scripts/latex_table.py "$f" > "${f%.raw}.tex"
+  echo "Converted $f to ${f%.raw}.tex"
+done


### PR DESCRIPTION
This PR slightly changes the CMake config such that we can manually assign the architecture we want to compile to, e.g.:
```
cmake -B build -DSIMPLE_FAST_FLOAT_BENCHMARK_MARCH=x86-64-v4
```

It also adds the `scripts/test_x86_levels.bash` file to automatically compile and benchmark the different x86-64 architectural levels (https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels).