### PR TITLE
updating fmt to version 12 and use compile-time format strings

### DIFF
--- a/benchmarks/algorithms.h
+++ b/benchmarks/algorithms.h
@@ -18,7 +18,7 @@
 #endif
 
 #include <fmt/format.h>
-
+#include <fmt/compile.h>
 #include <array>
 #include <span>
 
@@ -287,7 +287,9 @@ int to_string(T d, std::span<char>& buffer) {
 
 template<arithmetic_float T>
 int fmt_format(T d, std::span<char>& buffer) {
-  const auto it = fmt::format_to(buffer.data(), "{}", d);
+  // FMT_COMPILE is a macro provided by the {fmt} library that tells the library to fully process 
+  // a format string at compile time rather than at runtime.
+  const auto it = fmt::format_to(buffer.data(), FMT_COMPILE("{}"), d);
   return std::distance(buffer.data(), it);
 }
 
@@ -516,27 +518,29 @@ int snprintf(T d, std::span<char>& buffer) {
 
 template<arithmetic_float T>
 int fmt_format(T d, std::span<char>& buffer) {
+  // FMT_COMPILE is a macro provided by the {fmt} library that tells the library to fully process 
+  // a format string at compile time rather than at runtime.
   switch(BenchArgs<T>::fixedSize) {
-    case 0: return fmt::format_to(buffer.data(), "{}", d) - buffer.data();
-    case 1: return fmt::format_to(buffer.data(), "{:.1g}", d) - buffer.data();
-    case 2: return fmt::format_to(buffer.data(), "{:.2g}", d) - buffer.data();
-    case 3: return fmt::format_to(buffer.data(), "{:.3g}", d) - buffer.data();
-    case 4: return fmt::format_to(buffer.data(), "{:.4g}", d) - buffer.data();
-    case 5: return fmt::format_to(buffer.data(), "{:.5g}", d) - buffer.data();
-    case 6: return fmt::format_to(buffer.data(), "{:.6g}", d) - buffer.data();
-    case 7: return fmt::format_to(buffer.data(), "{:.7g}", d) - buffer.data();
-    case 8: return fmt::format_to(buffer.data(), "{:.8g}", d) - buffer.data();
-    case 9: return fmt::format_to(buffer.data(), "{:.9g}", d) - buffer.data();
-    case 10: return fmt::format_to(buffer.data(), "{:.10g}", d) - buffer.data();
-    case 11: return fmt::format_to(buffer.data(), "{:.11g}", d) - buffer.data();
-    case 12: return fmt::format_to(buffer.data(), "{:.12g}", d) - buffer.data();
-    case 13: return fmt::format_to(buffer.data(), "{:.13g}", d) - buffer.data();
-    case 14: return fmt::format_to(buffer.data(), "{:.14g}", d) - buffer.data();
-    case 15: return fmt::format_to(buffer.data(), "{:.15g}", d) - buffer.data();
-    case 16: return fmt::format_to(buffer.data(), "{:.16g}", d) - buffer.data();
-    case 17: return fmt::format_to(buffer.data(), "{:.17g}", d) - buffer.data();
+    case 0: return fmt::format_to(buffer.data(), FMT_COMPILE("{}"), d) - buffer.data();
+    case 1: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.1g}"), d) - buffer.data();
+    case 2: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.2g}"), d) - buffer.data();
+    case 3: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.3g}"), d) - buffer.data();
+    case 4: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.4g}"), d) - buffer.data();
+    case 5: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.5g}"), d) - buffer.data();
+    case 6: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.6g}"), d) - buffer.data();
+    case 7: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.7g}"), d) - buffer.data();
+    case 8: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.8g}"), d) - buffer.data();
+    case 9: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.9g}"), d) - buffer.data();
+    case 10: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.10g}"), d) - buffer.data();
+    case 11: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.11g}"), d) - buffer.data();
+    case 12: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.12g}"), d) - buffer.data();
+    case 13: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.13g}"), d) - buffer.data();
+    case 14: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.14g}"), d) - buffer.data();
+    case 15: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.15g}"), d) - buffer.data();
+    case 16: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.16g}"), d) - buffer.data();
+    case 17: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.17g}"), d) - buffer.data();
     default:
-      return fmt::format_to(buffer.data(), "{:.17g}", d) - buffer.data();
+      return fmt::format_to(buffer.data(), FMT_COMPILE("{:.17g}"), d) - buffer.data();
   }
 }
 

--- a/benchmarks/algorithms.h
+++ b/benchmarks/algorithms.h
@@ -522,25 +522,25 @@ int fmt_format(T d, std::span<char>& buffer) {
   // a format string at compile time rather than at runtime.
   switch(BenchArgs<T>::fixedSize) {
     case 0: return fmt::format_to(buffer.data(), FMT_COMPILE("{}"), d) - buffer.data();
-    case 1: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.1g}"), d) - buffer.data();
-    case 2: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.2g}"), d) - buffer.data();
-    case 3: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.3g}"), d) - buffer.data();
-    case 4: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.4g}"), d) - buffer.data();
-    case 5: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.5g}"), d) - buffer.data();
-    case 6: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.6g}"), d) - buffer.data();
-    case 7: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.7g}"), d) - buffer.data();
-    case 8: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.8g}"), d) - buffer.data();
-    case 9: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.9g}"), d) - buffer.data();
-    case 10: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.10g}"), d) - buffer.data();
-    case 11: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.11g}"), d) - buffer.data();
-    case 12: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.12g}"), d) - buffer.data();
-    case 13: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.13g}"), d) - buffer.data();
-    case 14: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.14g}"), d) - buffer.data();
-    case 15: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.15g}"), d) - buffer.data();
-    case 16: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.16g}"), d) - buffer.data();
-    case 17: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.17g}"), d) - buffer.data();
+    case 1: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.1}"), d) - buffer.data();
+    case 2: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.2}"), d) - buffer.data();
+    case 3: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.3}"), d) - buffer.data();
+    case 4: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.4}"), d) - buffer.data();
+    case 5: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.5}"), d) - buffer.data();
+    case 6: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.6}"), d) - buffer.data();
+    case 7: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.7}"), d) - buffer.data();
+    case 8: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.8}"), d) - buffer.data();
+    case 9: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.9}"), d) - buffer.data();
+    case 10: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.10}"), d) - buffer.data();
+    case 11: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.11}"), d) - buffer.data();
+    case 12: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.12}"), d) - buffer.data();
+    case 13: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.13}"), d) - buffer.data();
+    case 14: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.14}"), d) - buffer.data();
+    case 15: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.15}"), d) - buffer.data();
+    case 16: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.16}"), d) - buffer.data();
+    case 17: return fmt::format_to(buffer.data(), FMT_COMPILE("{:.17}"), d) - buffer.data();
     default:
-      return fmt::format_to(buffer.data(), FMT_COMPILE("{:.17g}"), d) - buffer.data();
+      return fmt::format_to(buffer.data(), FMT_COMPILE("{:.17}"), d) - buffer.data();
   }
 }
 

--- a/benchmarks/algorithms.h
+++ b/benchmarks/algorithms.h
@@ -287,7 +287,7 @@ int to_string(T d, std::span<char>& buffer) {
 
 template<arithmetic_float T>
 int fmt_format(T d, std::span<char>& buffer) {
-  // FMT_COMPILE is a macro provided by the {fmt} library that tells the library to fully process 
+  // FMT_COMPILE is a macro provided by the {fmt} library that tells the library to fully process
   // a format string at compile time rather than at runtime.
   const auto it = fmt::format_to(buffer.data(), FMT_COMPILE("{}"), d);
   return std::distance(buffer.data(), it);
@@ -518,7 +518,7 @@ int snprintf(T d, std::span<char>& buffer) {
 
 template<arithmetic_float T>
 int fmt_format(T d, std::span<char>& buffer) {
-  // FMT_COMPILE is a macro provided by the {fmt} library that tells the library to fully process 
+  // FMT_COMPILE is a macro provided by the {fmt} library that tells the library to fully process
   // a format string at compile time rather than at runtime.
   switch(BenchArgs<T>::fixedSize) {
     case 0: return fmt::format_to(buffer.data(), FMT_COMPILE("{}"), d) - buffer.data();
@@ -607,13 +607,13 @@ std::vector<BenchArgs<T>> initArgs(bool use_errol = false, size_t repeat = 0, si
     args.emplace_back("dragon4"           , wrap(s::dragon4<T>)           , true                                           , 10);
     args.emplace_back("netlib"            , wrap(s::netlib<T>)            , NETLIB_SUPPORTED && std::is_same_v<T, double>  , 10);
     args.emplace_back("errol3"            , wrap(s::errol3<T>)            , ERROL_SUPPORTED && use_errol);
-    args.emplace_back("fmt_format"        , wrap(s::fmt_format<T>)        , true);
+    args.emplace_back("fmt_format 12.1.0" , wrap(s::fmt_format<T>)        , true);
     // args.emplace_back("grisu2"            , wrap(s::grisu2<T>)            , std::is_same_v<T, double>);
     args.emplace_back("grisu3"            , wrap(s::grisu3<T>)            , std::is_same_v<T, double>);
     args.emplace_back("grisu_exact"       , wrap(s::grisu_exact<T>)       , true);
     args.emplace_back("schubfach"         , wrap(s::schubfach<T>)         , true);
     args.emplace_back("dragonboxlm"       , wrap(s::dragonboxlm<T>)       , true);
-    args.emplace_back("dragonbox"         , wrap(s::dragonbox<T>)         , true);
+    args.emplace_back("dragonbox 1.1.3"   , wrap(s::dragonbox<T>)         , true);
     args.emplace_back("ryu"               , wrap(s::ryu<T>)               , true);
     args.emplace_back("teju_jagua"        , wrap(s::teju_jagua<T>)        , true);
     args.emplace_back("double_conversion" , wrap(s::double_conversion<T>) , true);
@@ -631,7 +631,7 @@ std::vector<BenchArgs<T>> initArgs(bool use_errol = false, size_t repeat = 0, si
     args.emplace_back("netlib"            , wrap(f::netlib<T>)            , NETLIB_SUPPORTED     , 10);
     args.emplace_back("abseil"            , wrap(f::abseil<T>)            , ABSEIL_SUPPORTED);
     args.emplace_back("snprintf"          , wrap(f::snprintf<T>)          , true);
-    args.emplace_back("fmt_format"        , wrap(f::fmt_format<T>)        , true);
+    args.emplace_back("fmt_format 12.1.0" , wrap(f::fmt_format<T>)        , true);
     args.emplace_back("ryu"               , wrap(f::ryu<T>)               , std::is_same_v<T, double>);
     args.emplace_back("double_conversion" , wrap(f::double_conversion<T>) , true);
     args.emplace_back("std::to_chars"     , wrap(f::std_to_chars<T>)      , TO_CHARS_SUPPORTED);

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -157,7 +157,7 @@ target_include_directories(dragon_schubfach_lib PUBLIC
     ${drachennest_SOURCE_DIR}/src
 )
 
-CPMAddPackage("gh:fmtlib/fmt#11.1.4")
+CPMAddPackage("gh:fmtlib/fmt#12.1.0")
 CPMAddPackage(
   GITHUB_REPOSITORY jarro2783/cxxopts
   VERSION 3.2.0


### PR DESCRIPTION
Fixes https://github.com/fastfloat/float_serialization_benchmark/issues/50

This follows comments by a few people, including @vitaut (the fmt author). 



These changes drastically change change the performance of fmt, for the better.

On my Apple M4.... before...
```
./build/benchmarks/benchmark -f data/canada.txt
fmt_format                    :   586.68 MB/s (+/- 6.6 %)     1.87 MB     28.64 ns/f    34.92 Mfloat/s
```

after...
```
./build/benchmarks/benchmark -f data/canada.txt 
fmt_format                    :   906.36 MB/s (+/- 4.7 %)     1.87 MB     18.54 ns/f    53.95 Mfloat/s
```

In context, this makes (in one test), the fmt library much closer to `std::to_chars`.

```
dragon4                       :   111.95 MB/s (+/- 3.1 %)     1.87 MB    150.06 ns/f     6.66 Mfloat/s
netlib                        :    20.57 MB/s (+/- 0.9 %)     1.87 MB    816.58 ns/f     1.22 Mfloat/s
fmt_format                    :   582.34 MB/s (+/- 5.6 %)     1.87 MB     28.85 ns/f    34.66 Mfloat/s
grisu3                        :   701.22 MB/s (+/- 9.1 %)     1.87 MB     23.96 ns/f    41.74 Mfloat/s
grisu_exact                   :  1235.86 MB/s (+/- 8.8 %)     2.09 MB     15.21 ns/f    65.74 Mfloat/s
schubfach                     :  1389.48 MB/s (+/- 10.1 %)     1.87 MB     12.09 ns/f    82.71 Mfloat/s
dragonboxlm                   :  2319.66 MB/s (+/- 11.6 %)     2.20 MB      8.54 ns/f   117.15 Mfloat/s
dragonbox                     :  1985.19 MB/s (+/- 10.3 %)     2.09 MB      9.47 ns/f   105.60 Mfloat/s
ryu                           :  1551.55 MB/s (+/- 8.0 %)     2.09 MB     12.12 ns/f    82.53 Mfloat/s
teju_jagua                    :  1569.40 MB/s (+/- 9.1 %)     2.20 MB     12.62 ns/f    79.26 Mfloat/s
swiftDtoa                     :  1059.53 MB/s (+/- 10.0 %)     1.87 MB     15.86 ns/f    63.07 Mfloat/s
yy_double                     :  2038.28 MB/s (+/- 10.8 %)     1.87 MB      8.24 ns/f   121.32 Mfloat/s
std::to_chars                 :  1078.68 MB/s (+/- 9.9 %)     1.87 MB     15.57 ns/f    64.21 Mfloat/s
```


Context: Daniel Lemire, "Converting floats to strings quickly," in Daniel Lemire's blog, February 1, 2026, https://lemire.me/blog/2026/02/01/converting-floats-to-strings-quickly/.