### PR TITLE
add xjb 1.4.0 algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently, the following approaches are compared:
   - [schubfach](https://github.com/abolz/Drachennest/blob/master/src/schubfach_64.cc)
   - [Dragonbox](https://github.com/jk-jeon/dragonbox)
   - [Ryu](https://github.com/ulfjack/ryu)
+  - [xjb](https://github.com/xjb714/xjb)
   - [double-conversion](https://github.com/google/double-conversion)
   - [Abseil](https://github.com/abseil/abseil-cpp)
   - [Teju Jagua](https://github.com/cassioneri/teju_jagua)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -67,6 +67,13 @@ else()
     target_compile_definitions(benchmark_deps INTERFACE ERROL_SUPPORTED=0)
 endif()
 
+if(TARGET xjb AND NOT MSVC)
+    target_link_libraries(benchmark_deps INTERFACE xjb)
+    target_compile_definitions(benchmark_deps INTERFACE XJB_SUPPORTED=1)
+else()
+    target_compile_definitions(benchmark_deps INTERFACE XJB_SUPPORTED=0)
+endif()
+
 target_link_libraries(benchmark_deps INTERFACE fmt)
 target_link_libraries(benchmark_deps INTERFACE cxxopts)
 
@@ -108,4 +115,3 @@ if(TO_CHARS_OK AND FROM_CHARS_OK)
 
     target_link_libraries(thoroughfloat64 PUBLIC benchmark_deps)
 endif(TO_CHARS_OK AND FROM_CHARS_OK)
-

--- a/benchmarks/algorithms.h
+++ b/benchmarks/algorithms.h
@@ -39,6 +39,9 @@
 #if SWIFT_LIB_SUPPORTED
 #include "swift/Runtime/SwiftDtoa.h"
 #endif
+#if XJB_SUPPORTED
+#include "ftoa.h"
+#endif
 #if (__SIZEOF_INT128__ == 16) && (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER))
 #include "yy_double.h"
 #define YY_DOUBLE_SUPPORTED 1
@@ -362,6 +365,17 @@ int zmij(T d, std::span<char>& buffer) {
 }
 
 template<arithmetic_float T>
+int xjb(T d, std::span<char>& buffer) {
+#if XJB_SUPPORTED
+  const char* end_ptr = xjb_ftoa(d, buffer.data());
+  return end_ptr - buffer.data();
+#else
+  std::cerr << "xjb not supported" << std::endl;
+  std::abort();
+#endif
+}
+
+template<arithmetic_float T>
 int teju_jagua(T d, std::span<char>& buffer) {
   const auto fields = teju::traits_t<T>::teju(d);
   char * output = buffer.data();
@@ -622,6 +636,7 @@ std::vector<BenchArgs<T>> initArgs(bool use_errol = false, size_t repeat = 0, si
     args.emplace_back("dragonboxlm"       , wrap(s::dragonboxlm<T>)       , true);
     args.emplace_back("dragonbox 1.1.3"   , wrap(s::dragonbox<T>)         , true);
     args.emplace_back("ryu"               , wrap(s::ryu<T>)               , true);
+    args.emplace_back("xjb 1.4.0"         , wrap(s::xjb<T>)               , XJB_SUPPORTED);
     args.emplace_back("teju_jagua"        , wrap(s::teju_jagua<T>)        , true);
     args.emplace_back("double_conversion" , wrap(s::double_conversion<T>) , true);
     args.emplace_back("swiftDtoa"         , wrap(s::swiftDtoa<T>)         , SWIFT_LIB_SUPPORTED);

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -64,6 +64,15 @@ set(ryu_SOURCE_DIR ${ryu_SOURCE_DIR} PARENT_SCOPE)
 message(STATUS "ryu source directory: ${ryu_SOURCE_DIR}")
 
 FetchContent_Declare(
+        xjb
+        GIT_REPOSITORY https://github.com/xjb714/xjb.git
+        GIT_TAG tags/v1.4.0
+        GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(xjb)
+target_include_directories(xjb PUBLIC ${xjb_SOURCE_DIR}/src)
+
+FetchContent_Declare(
         grisu-exact
         GIT_REPOSITORY https://github.com/jk-jeon/Grisu-Exact
         GIT_TAG 4279e63faa301c03112f56f9ee4ed8bdff947fee


### PR DESCRIPTION
Adds the [xjb algorithm](https://github.com/xjb714/xjb).
It becomes the fastest algorithm for both float and double values, on both gcc and clang.

